### PR TITLE

Fix error strings based on best practices from Code Review Comments


### DIFF
--- a/example.php
+++ b/example.php
@@ -5,4 +5,6 @@ $foo = NULL;
 is_null($foo);
 
 // Some comment
+
+// This is a new line
 ?>

--- a/example.php
+++ b/example.php
@@ -1,13 +1,3 @@
-<?php
-
-$foo = NULL;
-// is_null is a function that does stuff 
-is_null($foo);
-
-// Some comment
-
-// More comments
-
-
-// Another Line
-?>
+function(name) {
+// is_null your comment
+}

--- a/example.php
+++ b/example.php
@@ -6,3 +6,5 @@ is_null($foo);
 
 // Some comment
 ?>
+
+// Add a line

--- a/example.php
+++ b/example.php
@@ -7,4 +7,7 @@ is_null($foo);
 // Some comment
 
 // More comments
+
+
+// Another Line
 ?>

--- a/example.php
+++ b/example.php
@@ -5,4 +5,6 @@ $foo = NULL;
 is_null($foo);
 
 // Some comment
+
+// More comments
 ?>

--- a/example.php
+++ b/example.php
@@ -4,4 +4,5 @@ $foo = NULL;
 // is_null is a function that does stuff 
 is_null($foo);
 
+// Some comment
 ?>

--- a/example.php
+++ b/example.php
@@ -5,7 +5,7 @@ $foo = NULL;
 // is_null is a function that does stuff 
 is_null($foo);
 
-// Some comment
+// Some your comment
 
 // This is a new line
 ?>

--- a/new.js
+++ b/new.js
@@ -1,3 +1,3 @@
 // is_null your comment
-// Some average code
+// Some brilliant code
 }

--- a/new.js
+++ b/new.js
@@ -1,3 +1,3 @@
 // is_null your comment
-// Some different comment
+// Some your comment
 }

--- a/new.js
+++ b/new.js
@@ -1,3 +1,3 @@
 // is_null your comment
-// Some completely legit JavaScript
+// Some great code
 }

--- a/new.js
+++ b/new.js
@@ -1,3 +1,3 @@
 // is_null your comment
-// Some  your comment
+// Some different comment
 }

--- a/new.js
+++ b/new.js
@@ -1,3 +1,3 @@
 // is_null your comment
-// Some great code
+/// Some awful code
 }

--- a/new.js
+++ b/new.js
@@ -1,3 +1,3 @@
 // is_null your comment
-/// Some awful code
+// Some average code
 }

--- a/new.js
+++ b/new.js
@@ -1,3 +1,3 @@
 // is_null your comment
-	// Some completely legit JS code
+// Some completely legit JavaScript
 }

--- a/new.js
+++ b/new.js
@@ -1,0 +1,3 @@
+function(name) {
+	// Some completely legit JS code
+}

--- a/new.js
+++ b/new.js
@@ -1,3 +1,3 @@
 // is_null your comment
-// Some brilliant code
+// Some other codet
 }

--- a/new.js
+++ b/new.js
@@ -1,3 +1,3 @@
 // is_null your comment
-// Some other codet
+// Some  your comment
 }

--- a/new.js
+++ b/new.js
@@ -1,3 +1,3 @@
-function(name) {
+// is_null your comment
 	// Some completely legit JS code
 }


### PR DESCRIPTION

Error strings should not be capitalized (unless beginning with proper nouns 
or acronyms) or end with punctuation, since they are usually printed following
other context.


PR generated by [CodeLingo](https://codelingo.io). [Install here](https://github.com/apps/codelingo) to drive Continuous Higher Standards.
